### PR TITLE
Model parameter save/load method

### DIFF
--- a/model_parameters/.gitignore
+++ b/model_parameters/.gitignore
@@ -1,0 +1,5 @@
+# Saved model parameters will live here
+*
+!.gitignore
+!*.py
+!*.ipynb

--- a/model_parameters/save_load_model_parameters_demo.ipynb
+++ b/model_parameters/save_load_model_parameters_demo.ipynb
@@ -1,0 +1,22 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Demos functionality of the save_load_model_parameters module\n",
+    "import save_load_model_parameters\n",
+    "import torch"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/model_parameters/save_load_model_parameters_demo.ipynb
+++ b/model_parameters/save_load_model_parameters_demo.ipynb
@@ -2,19 +2,261 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
     "# Demos functionality of the save_load_model_parameters module\n",
+    "# To execute, move this .ipynb file to the root folder\n",
     "import save_load_model_parameters\n",
     "import torch"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create some dummy objects to save parameters from\n",
+    "dummy_module = torch.nn.Linear(in_features=5, out_features=3)\n",
+    "dummy_optimizer = torch.optim.Adam(dummy_module.parameters(), lr=3.14)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(OrderedDict([('weight',\n",
+       "               tensor([[-0.1858, -0.0283,  0.1094,  0.3646,  0.0810],\n",
+       "                       [ 0.2257, -0.4112,  0.2516, -0.0552, -0.3183],\n",
+       "                       [-0.0974, -0.2699, -0.1971, -0.2375,  0.0078]])),\n",
+       "              ('bias', tensor([0.1548, 0.3654, 0.4432]))]),\n",
+       " {'state': {},\n",
+       "  'param_groups': [{'lr': 3.14,\n",
+       "    'betas': (0.9, 0.999),\n",
+       "    'eps': 1e-08,\n",
+       "    'weight_decay': 0,\n",
+       "    'amsgrad': False,\n",
+       "    'maximize': False,\n",
+       "    'foreach': None,\n",
+       "    'capturable': False,\n",
+       "    'differentiable': False,\n",
+       "    'fused': None,\n",
+       "    'params': [0, 1]}]})"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# We can see the parameters which will be saved to a file wtth .state_dict\n",
+    "dummy_module.state_dict(), dummy_optimizer.state_dict()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(True, True)"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Save the parameters to an output file\n",
+    "file_name_module = \"module_test\"\n",
+    "module_save_success = save_load_model_parameters.save_parameters(module_or_optimizer=dummy_module, file_name=file_name_module, overwrite=True)\n",
+    "\n",
+    "file_name_optimizer = \"optimizer_test\"\n",
+    "optimizer_save_success = save_load_model_parameters.save_parameters(module_or_optimizer=dummy_optimizer, file_name=file_name_optimizer, overwrite=True)\n",
+    "\n",
+    "module_save_success, optimizer_save_success"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(OrderedDict([('weight',\n",
+       "               tensor([[-0.1769, -0.2175, -0.3600, -0.1630, -0.0784],\n",
+       "                       [ 0.1794,  0.2874, -0.1988, -0.0282, -0.2725],\n",
+       "                       [ 0.0269, -0.0912, -0.1837, -0.1496,  0.4255]])),\n",
+       "              ('bias', tensor([ 0.1043, -0.1002,  0.1690]))]),\n",
+       " {'state': {},\n",
+       "  'param_groups': [{'lr': 0.001,\n",
+       "    'betas': (0.9, 0.999),\n",
+       "    'eps': 1e-08,\n",
+       "    'weight_decay': 0,\n",
+       "    'amsgrad': False,\n",
+       "    'maximize': False,\n",
+       "    'foreach': None,\n",
+       "    'capturable': False,\n",
+       "    'differentiable': False,\n",
+       "    'fused': None,\n",
+       "    'params': [0, 1]}]})"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Now we can recall the model parameters from their files\n",
+    "\n",
+    "# First, create new objects to load our parameters into\n",
+    "load_module = torch.nn.Linear(in_features=5, out_features=3)\n",
+    "load_optimizer = torch.optim.Adam(dummy_module.parameters(), lr=0.001)\n",
+    "\n",
+    "# We can see the states of these objects after creation with.state_dict() again:\n",
+    "load_module.state_dict(), load_optimizer.state_dict()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(True, True)"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Now we can recall the parameters from our saved files into the new objects\n",
+    "module_load_success = save_load_model_parameters.load_parameters(module_or_optimizer=load_module, file_name=file_name_module)\n",
+    "\n",
+    "optimizer_load_success = save_load_model_parameters.load_parameters(module_or_optimizer=load_optimizer, file_name=file_name_optimizer)\n",
+    "\n",
+    "module_load_success, optimizer_load_success"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(OrderedDict([('weight',\n",
+       "               tensor([[-0.1858, -0.0283,  0.1094,  0.3646,  0.0810],\n",
+       "                       [ 0.2257, -0.4112,  0.2516, -0.0552, -0.3183],\n",
+       "                       [-0.0974, -0.2699, -0.1971, -0.2375,  0.0078]])),\n",
+       "              ('bias', tensor([0.1548, 0.3654, 0.4432]))]),\n",
+       " OrderedDict([('weight',\n",
+       "               tensor([[-0.1858, -0.0283,  0.1094,  0.3646,  0.0810],\n",
+       "                       [ 0.2257, -0.4112,  0.2516, -0.0552, -0.3183],\n",
+       "                       [-0.0974, -0.2699, -0.1971, -0.2375,  0.0078]])),\n",
+       "              ('bias', tensor([0.1548, 0.3654, 0.4432]))]),\n",
+       " {'state': {},\n",
+       "  'param_groups': [{'lr': 3.14,\n",
+       "    'betas': (0.9, 0.999),\n",
+       "    'eps': 1e-08,\n",
+       "    'weight_decay': 0,\n",
+       "    'amsgrad': False,\n",
+       "    'maximize': False,\n",
+       "    'foreach': None,\n",
+       "    'capturable': False,\n",
+       "    'differentiable': False,\n",
+       "    'fused': None,\n",
+       "    'params': [0, 1]}]},\n",
+       " {'state': {},\n",
+       "  'param_groups': [{'lr': 3.14,\n",
+       "    'betas': (0.9, 0.999),\n",
+       "    'eps': 1e-08,\n",
+       "    'weight_decay': 0,\n",
+       "    'amsgrad': False,\n",
+       "    'maximize': False,\n",
+       "    'foreach': None,\n",
+       "    'capturable': False,\n",
+       "    'differentiable': False,\n",
+       "    'fused': None,\n",
+       "    'params': [0, 1]}]})"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# We can see that our module weights/bias and optimizer learning rate have been successfully\n",
+    "# updated to match the original values from the dummy objects\n",
+    "dummy_module.state_dict(), load_module.state_dict(), dummy_optimizer.state_dict(), load_optimizer.state_dict()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(False, False)"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# One last note, save_parameters() and load_parameters() will both return False if they fail due to\n",
+    "# a file not existing or not being able to be overwritten\n",
+    "\n",
+    "# File already exists and overwrite=False\n",
+    "module_save_success = save_load_model_parameters.save_parameters(module_or_optimizer=dummy_module, file_name=file_name_module, overwrite=False)\n",
+    "\n",
+    "# File doesn't exist\n",
+    "module_load_success = save_load_model_parameters.load_parameters(module_or_optimizer=load_module, file_name=\"not_a_file\")\n",
+    "\n",
+    "module_save_success, module_load_success"
    ]
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
-   "name": "python"
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.6"
   }
  },
  "nbformat": 4,

--- a/save_load_model_parameters.py
+++ b/save_load_model_parameters.py
@@ -1,0 +1,81 @@
+import os
+import torch
+
+_model_parameters_path = "model_parameters"
+_model_parameter_extension = ".pt"
+
+def _parameter_file_path(file_name: str) -> str:
+    # Add extension, if needed
+    if not file_name.endswith(_model_parameter_extension):
+        file_name = file_name + _model_parameter_extension
+    # Add to parameters folder
+    return os.path.join(_model_parameters_path, file_name)
+
+
+def save_parameters(module_or_optimizer: torch.nn.Module | torch.optim.Optimizer, file_name: str, overwrite: bool = False) -> bool:
+    """Saves the parameters of a `torch.nn.Module` or `torch.optim.Optimizer` to a file for later
+    recall
+
+    Args:
+        module_or_optimizer (torch.nn.Module | torch.optim.Optimizer): A module or optimizer whose
+        parameters will be saved; saveable parameters are listed by the module or optimizer's
+        `.state_dict()` method
+        file_name (str): The name of the file to save the model/optimizer parameters to. **NOTE**:
+        this should be a file name, not a path from the root directory; parameters are
+        automatically saved to the `./model_parameters` folder! A file extension of `.pt` is added
+        automatically if not included in `file_name`. 
+        overwrite (bool, optional): If True, overwrites an existing model parameter with a matching
+        `file_name`, if it exists. Defaults to False.
+
+    Returns:
+        bool: Whether or not the module or optimizer's parameters were saved to a file
+        successfully. False only if an existing model parameter with a matching `file_name` exists
+        and `overwrite` is set to False.
+    """  
+    
+    # Get the target file path
+    file_path = _parameter_file_path(file_name)
+
+    # Check for an existing file and return early if it would be erroneously overwritten
+    if (not overwrite) and os.path.exists(file_path):
+        return False
+    
+    # Write the parameter to the target file
+    torch.save(module_or_optimizer.state_dict(), file_path)
+
+    # No errors, return True
+    return True
+
+
+def load_parameters(module_or_optimizer: torch.nn.Module | torch.optim.Optimizer, file_name: str) -> bool:
+    """Loads the parameters of a `torch.nn.Module` or `torch.optim.Optimizer` from a file which
+    was previously created by `save_parameters()`
+
+    Args:
+        module_or_optimizer (torch.nn.Module | torch.optim.Optimizer): A module or optimizer whose
+        parameters will be restored from the save file; saveable parameters are listed by the
+        module or optimizer's `.state_dict()` method
+        file_name (str): The name of the file to load the model/optimizer parameters from.
+        **NOTE**: this should be a file name, not a path from the root directory; parameters are
+        automatically loaded from the `./model_parameters` folder! A file extension of `.pt` is
+        added automatically if not included in `file_name`. 
+
+    Returns:
+        bool: Whether or not the module or optimizer's parameters were loaded from a file
+        successfully. False only if no existing model parameter with a matching `file_name` was
+        found (likely because `save_parameters()` hasn't been called yet)
+    """ 
+
+    # Get the target file path
+    file_path = _parameter_file_path(file_name)
+
+    # Check if the file exists; if it doesn't, return early
+    if not os.path.exists(file_path):
+        return False
+    
+    # Load in the module/optimizer parameters
+    module_or_optimizer_state = torch.load(file_path)
+    module_or_optimizer.load_state_dict(module_or_optimizer_state)
+    
+    # No errors, return True
+    return True


### PR DESCRIPTION
Turns out, PyTorch's save/load functionality is more powerful than I initially thought, so I had to deviate from the original DoD somewhat. New method signatures are as-follows:
- `save_parameters(module_or_optimizer: torch.nn.Module | torch.optim.Optimizer, file_name: str, overwrite: bool = False) -> bool`
- `load_parameters(module_or_optimizer: torch.nn.Module | torch.optim.Optimizer, file_name: str) -> bool`

These will save/load parameters from any PyTorch `nn.Module` (our actual models) or `optim.Optimizer` (SGD, Adam, etc.) that we throw at it in the folder `./model_parameters`. Still todo is implementing an automatic save mechanism, but that will probably happen at the level of our model trainer utility.