### PR TITLE
CSV Formatting Changes

### DIFF
--- a/dataset.py
+++ b/dataset.py
@@ -81,11 +81,12 @@ class csv_reader:
         self._read_location = 0
     
     
-    def open_csv(self, csv_path: str) -> None:
+    def open_csv(self, csv_path: str, skip_header: bool = False) -> None:
         """Reads a csv file's contents
 
         Args:
             csv_path (str): The path to the csv file to read
+            skip_header (bool): If True, skips the first line of the specified CSV (the header). Defaults to False.
 
         Raises:
             ValueError: if an invalid csv_path was specified
@@ -101,6 +102,13 @@ class csv_reader:
         # Read the file
         with open(csv_path, encoding=csv_encoding) as csv_file:
             csv_reader = csv.reader(csv_file, delimiter=csv_delimiter, quotechar=csv_quotechar, doublequote=csv_doublequote)
+            
+            # Skip the first line if it is a header
+            if skip_header:
+                try:
+                    next(csv_reader)
+                except StopIteration:
+                    return
             
             for line_i, line_items in enumerate(csv_reader):
                 # Ignore blank lines

--- a/preprocessing/preprocessing_pipeline.py
+++ b/preprocessing/preprocessing_pipeline.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from reformat_data import format_data
 from train_val_split import split_in_train_and_validation
+from csv import QUOTE_ALL
 
 
 def run_preprocessing_pipeline(project_root: Path, train_path: Path, test_path: Path) -> None:
@@ -22,7 +23,7 @@ def run_preprocessing_pipeline(project_root: Path, train_path: Path, test_path: 
     print("\nDataframe shape for train\nExpected rows: 2400000", "\nActual rows: ", rows)
 
     # Write to csv
-    formatted_test.to_csv(project_root.joinpath("dataset", "formatted_test.csv"), index=False)
+    formatted_test.to_csv(project_root.joinpath("dataset", "formatted_test.csv"), index=False, quoting=QUOTE_ALL)
 
     # Split train in train and validation
     split_in_train_and_validation(formatted_train, 0.2)

--- a/preprocessing/reformat_data.py
+++ b/preprocessing/reformat_data.py
@@ -1,6 +1,7 @@
 import pandas as pd
 from pathlib import Path
 import os
+from csv import QUOTE_ALL
 
 
 def snap_reviews(rating: int):
@@ -49,8 +50,8 @@ def main():
     formatted_test = format_data(raw_test_path)
 
     # Write to csv
-    formatted_test.to_csv(project_root.joinpath("dataset", "formatted_test.csv"), index=False)
-    formatted_train.to_csv(project_root.joinpath("dataset", "formatted_train.csv"), index=False)
+    formatted_test.to_csv(project_root.joinpath("dataset", "formatted_test.csv"), index=False, quoting=QUOTE_ALL)
+    formatted_train.to_csv(project_root.joinpath("dataset", "formatted_train.csv"), index=False, quoting=QUOTE_ALL)
 
     # Check sizes
     print("--> Running format_data")

--- a/preprocessing/train_val_split.py
+++ b/preprocessing/train_val_split.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 import pandas as pd
 from sklearn.model_selection import train_test_split
+from csv import QUOTE_ALL
 
 
 def split_in_train_and_validation(train_data: Path | pd.DataFrame, validation_size: float) -> None:
@@ -25,8 +26,8 @@ def split_in_train_and_validation(train_data: Path | pd.DataFrame, validation_si
 
     # Save as CSV files - could be made to overwrite formatted train
     project_root = Path(__file__).parent.parent
-    train_df.to_csv(project_root.joinpath("dataset", "formatted_train.csv"), index=False)
-    val_df.to_csv(project_root.joinpath("dataset", "formatted_val.csv"), index=False)
+    train_df.to_csv(project_root.joinpath("dataset", "formatted_train.csv"), index=False, quoting=QUOTE_ALL)
+    val_df.to_csv(project_root.joinpath("dataset", "formatted_val.csv"), index=False, quoting=QUOTE_ALL)
 
 
 def main():


### PR DESCRIPTION
- `.csv` files from `pandas` are now saved with full quotation around all fields so that `dataset.csv_reader` still functions
- Added an option to `dataset.csv_reader` to ignore the first line of a csv (if it is header information)